### PR TITLE
make admin body class style specific

### DIFF
--- a/core/src/main/cfml/context/admin/resources/css/style42b.css.cfm
+++ b/core/src/main/cfml/context/admin/resources/css/style42b.css.cfm
@@ -29,7 +29,7 @@
 	min-height: 450px;
 	height: 100%;
 }
-body {
+body.web, body.server {
 	min-width:600px;
 	background:#f7f7f7 url(../img/web-back.png.cfm) repeat-x top;
 	margin:0;


### PR DESCRIPTION
otherwise, if you include a css library like bootstrap in an extension, it will redefine the default body style, by adding a class to the lucee admin body selector, any third party css library overriding the default body style won't affect the default admin body style