### PR TITLE
LDEV-5518 Don't force preserveCase in ComponentPageImpl for query or struct JSON

### DIFF
--- a/core/src/main/java/lucee/runtime/ComponentPageImpl.java
+++ b/core/src/main/java/lucee/runtime/ComponentPageImpl.java
@@ -77,6 +77,7 @@ import lucee.runtime.type.Collection;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.FunctionArgument;
 import lucee.runtime.type.KeyImpl;
+import lucee.runtime.type.QueryImpl;
 import lucee.runtime.type.Struct;
 import lucee.runtime.type.StructImpl;
 import lucee.runtime.type.UDF;
@@ -938,7 +939,14 @@ public abstract class ComponentPageImpl extends ComponentPage implements PagePro
 				prefix = pc.getApplicationContext().getSecureJsonPrefix();
 				if (prefix == null) prefix = "";
 			}
-			pc.forceWrite(prefix + converter.serialize(pc, rtn, qf, true));
+
+			// If rtn is a query or struct, set preserveCase to null to allow SerializationSettings
+			// to determine case preservation in JSONConverter. Otherwise set preserveCase to true.
+			Boolean preserveCase = (rtn instanceof QueryImpl || rtn instanceof StructImpl) ? null : true;
+			if (rtn instanceof QueryImpl || rtn instanceof StructImpl) {
+				preserveCase = null;
+			}
+			pc.forceWrite(prefix + converter.serialize(pc, rtn, qf, preserveCase));
 		}
 		// CFML
 		else if (UDF.RETURN_FORMAT_SERIALIZE == props.format) {

--- a/test/general/SerializeJSON.cfc
+++ b/test/general/SerializeJSON.cfc
@@ -59,6 +59,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( mystruct );
 				expect(find("Name", jsonObject)).toBeGT(0);
 				expect(find("id", jsonObject)).toBeGT(0);
+				expect(find("NAME", jsonObject)).toBe(0);
+				expect(find("ID", jsonObject)).toBe(0);
 			});
 
 			it(title="Checking serializeJSON() with preserve case for structkey(preservecaseforstructkey) Eq to false", body=function(){
@@ -87,6 +89,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( data );
 				expect(find("DateJoined", jsonObject)).toBeGT(0);
 				expect(find("ID", jsonObject)).toBeGT(0);
+				expect(find("DATEJOINED", jsonObject)).toBe(0);
 			});
 
 			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
@@ -97,6 +100,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( data );
 				expect(find("DATEJOINED", jsonObject)).toBeGT(0);
 				expect(find("ID", jsonObject)).toBeGT(0);
+				expect(find("DateJoined", jsonObject)).toBe(0);
 			});
 			// if we serializeQueryAs struct with preserveCaseForQueryColumn true lucee fails to maintain preserveCase for query column
 			xit(title="Checking serializeJSON() with preserveCaseForQueryColumn is true & serializeQueryAs struct", body=function(){
@@ -109,6 +113,7 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var jsonObject = serializeJSON( data );
 				expect(find("DateJoined", jsonObject)).toBeGT(0);
 				expect(find("ID", jsonObject)).toBeGT(0);
+				expect(find("DATEJOINED", jsonObject)).toBe(0);
 			});
 		});
 
@@ -126,6 +131,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var json = res.filecontent;
 				expect(find("DateJoined", json)).toBeGT( 0 );
 				expect(find("Id", json)).toBeGT( 0 );
+				expect(find("DATEJOINED", json)).toBe( 0 );
+				expect(find("ID", json)).toBe( 0 );
 			});
 
 			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
@@ -139,6 +146,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				);
 				expect(isJson(res.filecontent)).toBeTrue();
 				var json = res.filecontent;
+				expect(find("DATEJOINED", json)).toBeGT( 0 );
+				expect(find("ID", json)).toBeGT( 0 );
 				expect(find("DateJoined", json)).toBe( 0 );
 				expect(find("Id", json)).toBe( 0 );
 			});
@@ -160,9 +169,11 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				debug(json);
 				expect(find("Name", json)).toBeGT( 0 );
 				expect(find("Id", json)).toBeGT( 0 );
+				expect(find("NAME", json)).toBe( 0 );
+				expect(find("ID", json)).toBe( 0 );
 			});
 
-			xit(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
+			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
 				var uri=createURI("serializeJson/remoteQuery.cfc");
 				var res=_InternalRequest(
 					template:uri,
@@ -175,6 +186,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				expect(isJson(res.filecontent)).toBeTrue();
 				var json = res.filecontent;
 				debug(json);
+				expect(find("NAME", json)).toBeGT( 0 );
+				expect(find("ID", json)).toBeGT( 0 );
 				expect(find("Name", json)).toBe( 0 );
 				expect(find("Id", json)).toBe( 0 );
 			});
@@ -194,6 +207,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				var json = res.filecontent;
 				expect(find("DateJoined", json)).toBeGT( 0 );
 				expect(find("Id", json)).toBeGT( 0 );
+				expect(find("DATEJOINED", json)).toBe( 0 );
+				expect(find("ID", json)).toBe( 0 );
 			});
 
 			it(title="Checking serializeJSON() with preserveCaseForQueryColumn is false", body=function(){
@@ -207,6 +222,8 @@ component extends="org.lucee.cfml.test.LuceeTestCase"{
 				);
 				expect(isJson(res.filecontent)).toBeTrue();
 				var json = res.filecontent;
+				expect(find("DATEJOINED", json)).toBeGT( 0 );
+				expect(find("ID", json)).toBeGT( 0 );
 				expect(find("DateJoined", json)).toBe( 0 );
 				expect(find("Id", json)).toBe( 0 );
 			});


### PR DESCRIPTION
When rendering queries or structs as JSON in ComponentPageImpl, pass null preserveCase to allow SerializationSettings to determine case preservation behavior. For other return types, continue to pass preserveCase=true.